### PR TITLE
Create post install hook for dependency instalation

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -5,7 +5,8 @@ var utils = require('./utils'),
     path = require('path'),
     _ = require('lodash'),
     fs = require('fs'),
-    mkdirp = require('mkdirp');
+    mkdirp = require('mkdirp'),
+    chprocess = require('child_process');
 
 var basePath = process.cwd(),
     pathSep = '/',
@@ -161,8 +162,8 @@ exports.installDependency = function installDependency(deps, key, cfg, paths, si
             glob(dep, function(err, files) {
                 if (err) {
                     if (!silent) {
-                    	console.log(('Error globbing \t' + key + ' : ' + dep).red);
-                    	console.log(('\t\t' + err).red);
+                        console.log(('Error globbing \t' + key + ' : ' + dep).red);
+                        console.log(('\t\t' + err).red);
                     }
                 } else {
                     async.each(files, function(f, callback) {
@@ -171,7 +172,21 @@ exports.installDependency = function installDependency(deps, key, cfg, paths, si
                 }
             });
         }
-    }, callback);
+    }, function(){
+        var scr = cfg.scripts;
+        if (scr){
+            scr = scr.postinstall;
+            scr = _.isString(scr) ? scr : (scr[key] || scr.all);
+            if (scr) {
+                if (scr.type === 'module'){
+                    // in future fork child process with sending messages(args and dependency file list)
+                } else {
+                    var child = chprocess.spawn((scr.executor || 'node'), [(scr.script || scr).replace(basePath, '')].concat(scr.args || []));
+                }
+            }
+        }
+        callback();
+    });
 };
 
 exports.removeComponentsDir = function(callback) {


### PR DESCRIPTION
In my project, I needed to slightly modify the installed files of dependencies. 

According to this idea to create a set of events on which to run some scripts.

At present, the function simply executes the configured script. 

In the future it is planned to separate these two types of scripts: 
1) simple script (not only on nodejs) 
2) the module on nodejs running through the fork which will be sent a list of command-line arguments, and a list of files that were installed as part of this dependence. 
Implemented so far only the first type. 

an example of the configuration and script code:

```json
/*bower.json*/
{
  "install": {
    "path": {
      "jasmine-jquery" : "tests/libs/jasmine/plugins/jasmine-jquery",
    },    
    "scripts" : {
       "postinstall" : {
          "jasmine-jquery" : "tests/scripts/JasmineJqueryPluginPostInstallScript.js"
       }
    }
  },
  "dependencies": {
    "jasmine-jquery": "~2.0.5",
  }
}
```

```js
/*JasmineJqueryPluginPostInstallScript.js*/
var fs = require('fs');
var someFile = 'tests/libs/jasmine/plugins/jasmine-jquery/jasmine-jquery.js';
fs.readFile(someFile, 'utf8', function (err,data) {
  if (err) {
    return console.log(err);
  }
  var result = data.replace(/window\.jQuery/g, 'jq2');

  fs.writeFile(someFile, result, 'utf8', function (err) {
    if (err) return console.log(err);
  });
});
```

This was done due to the fact that the product I'm using one version of jquery and the plugin requires a different version of this and I need to safely connect two versions but the original version of the file does not let me do it.