### PR TITLE
Regular Expression matching in path map

### DIFF
--- a/bower-installer.spec.js
+++ b/bower-installer.spec.js
@@ -218,5 +218,19 @@ describe("Bower Installer", function() {
 			], run);			
 		});
 	}, TIMEOUT);
+
+	it('Should pass regExp', function(run) {
+		exec('node ../../bower-installer.js', {cwd: path.join(process.cwd(), 'test/regExp')}, function(err, stdout, stderr) {
+			expect(err).toBeNull();
+			expectFilesToExist([
+				'test/regExp/build/src/Asset/Lib/flair/Font/ubuntu-r-webfont.woff',
+				'test/regExp/build/src/Asset/Lib/flair/Font/ubuntu-r-webfont.woff2',
+				'test/regExp/build/src/Asset/Lib/flair/Font/ubuntu-r-webfont.eot',
+				'test/regExp/build/src/Asset/Lib/flair/Font/ubuntu-r-webfont.ttf',
+				'test/regExp/build/src/Asset/Lib/flair/Font/ubuntu.font.css',
+				'test/regExp/build/src/Style/Lib/flair/base.scss',
+			], run);
+		});
+	}, TIMEOUT);
 });
 

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -51,9 +51,11 @@ function installFile(f, pakcfg, paths, dep, silent, callback) {
         path = utils.parsePath(paths.all, pakcfg) + pathSep + key + subDir;
 
     } else {
-        // Determine the path by the file extension type		
-        
-		path = paths[utils.getExtension(f_name)];
+        // Determine the path by regular expression...
+		path = utils.getPathByRegExp(f_name, paths)
+            // ...or by file extension.
+            || paths[utils.getExtension(f_name)]
+
         if (path && typeof path !== 'undefined') {
 
             if (!utils.hasVariableInPath(path)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -64,9 +64,32 @@ exports.getJSON = function(path, pathSep, filename) {
   return pakcfg;
 }
 
+// Loops over the paths map looking for a RegExp formatted key, returning the
+// path for the first match against the provided filename. Returns null if no
+// match is made.
+exports.getPathByRegExp = function getPathByRegExp(filename, paths) {
+  for(var key in paths) {
+    if(!paths.hasOwnProperty(key)) {
+      continue;
+    }
+
+    if(key.indexOf("/") === 0
+    && key.lastIndexOf("/") > 0) {
+      // Assume the key is a RegExp formatted string.
+      var regExp = new RegExp(key.substring(1, key.lastIndexOf("/")) );
+      if(filename.match(regExp)) {
+        return paths[key];
+      }
+    }
+  }
+
+  return null;
+}
+
 exports.getExtension = function getExtension(filename) {
     return pathLib.extname(filename||'').slice(1);
 }
+
 
 exports.copyFile = function copyFile(source, target, cb) {
   var cbCalled = false;

--- a/test/regExp/bower.json
+++ b/test/regExp/bower.json
@@ -1,0 +1,17 @@
+{
+    "name": "test",
+    "version": "0.0.1",
+
+    "dependencies": {
+        "normalize-css": "latest",
+        "flair": "latest"
+    },
+
+    "install": {
+        "path": {
+            "/\\.font\\.css/": "build/src/Asset/Lib/{name}/Font",
+            "/[sc|le]ss$/": "build/src/Style/Lib/{name}",
+            "/(woff.*|eot|ttf)$/": "build/src/Asset/Lib/{name}/Font"
+        }
+    }
+}


### PR DESCRIPTION
```
{
    "name": "test",
    "version": "0.0.1",

    "dependencies": {
        "normalize-css": "latest",
        "flair": "latest"
    },

    "install": {
        "path": {
            "/\\.font\\.css/": "build/src/Asset/Lib/{name}/Font",
            "/[sc|le]ss$/": "build/src/Style/Lib/{name}",
            "/(woff.*|eot|ttf)$/": "build/src/Asset/Lib/{name}/Font"
        }
    }
}
```

This PR adds the ability to put regular expressions into the path key, rather than just file extensions. In the above example, you can see:

* Any CSS files that end with ".font.css" will be placed into the /build/src/Asset/Lib/{name}/Font directory.
* Any SCSS or LESS filess will be placed into the /build/src/Style/Lib/{name} directory.
* Any font files (woff, woff2, eot, ttf) will be placed into the /build/src/Asset/Lib/{name}/Font directory.

The new implementation has minimal influence over the existing code and comes with tests. I'm using this technique in production projects, it would be nice to see a swift merge. Thanks.