### PR TITLE
do not copy file if it has the same source and target paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ test/keyword/build
 test/keyword/bower_components
 test/multiDirGlobWithSameNestedFolder/build
 test/multiDirGlobWithSameNestedFolder/bower_components
+test/regExp/bower_components/
+test/regExp/build/
+test/regExp/UFL.txt

--- a/bower-installer.spec.js
+++ b/bower-installer.spec.js
@@ -49,7 +49,7 @@ describe("Bower Installer", function() {
 			expectFilesToExist([
 				'test/basic/build/src/jquery/jquery.js',
 				'test/basic/build/src/jquery-ui/jquery-ui.js'
-			], run);			
+			], run);
 		});
 	}, TIMEOUT);
 	it('Should pass bootstrap', function(run) {
@@ -63,7 +63,7 @@ describe("Bower Installer", function() {
 				'test/bootstrap/build/src/bootstrap/glyphicons-halflings-regular.svg',
 				'test/bootstrap/build/src/bootstrap/bootstrap.css',
 				'test/bootstrap/build/src/jquery/jquery.js'
-			], run);			
+			], run);
 		});
 	}, TIMEOUT);
 
@@ -71,7 +71,7 @@ describe("Bower Installer", function() {
 		exec('node ../../bower-installer.js', {cwd: path.join(process.cwd(), 'test/full')}, function(err, stdout, stderr) {
 			expect(err).toBeNull();
 			expectFilesToExist([
-				'test/full/build/src/backbone-nested/backbone-nested.js',
+				'test/full/build/src/backbone-nested/backbone-nested-models.js',
 				'test/full/build/src/backbone/backbone.js',
 				'test/full/build/src/buster-jquery-assertions/buster-jquery-assertions.js',
 				'test/full/build/src/buster.js/buster-test.css',
@@ -90,7 +90,7 @@ describe("Bower Installer", function() {
 				'test/full/build/src/d3/d3.js',
 				'test/full/build/src/jquery-ui/jquery-ui.js',
 				'test/full/build/src/speak.js/speakGenerator.js',
-			], run);			
+			], run);
 		});
 	}, TIMEOUT);
 
@@ -111,7 +111,7 @@ describe("Bower Installer", function() {
 				"test/multiDirGlob/build/src/bootstrap/css/bootstrap.min.css",
 				"test/multiDirGlob/build/src/jquery/jquery.js",
 				"test/multiDirGlob/build/src/bootstrap/css/bootstrap.css.map"
-			], run);			
+			], run);
 		});
 	}, TIMEOUT);
 
@@ -121,7 +121,7 @@ describe("Bower Installer", function() {
 			expectFilesToExist([
 				'test/ignore/build/src/ember-model/ember-model.js',
 				'test/ignore/build/src/jquery/jquery.js'
-			], run);			
+			], run);
 		});
 	}, TIMEOUT);
 
@@ -133,7 +133,7 @@ describe("Bower Installer", function() {
 				'test/mapping/build/src/ember-easyForm/subdirectory/ember-easyForm.js',
 				'test/mapping/build/src/jquery/jquery.js',
 				'test/mapping/build/src/jquery-ui/jquery-ui.js'
-			], run);			
+			], run);
 		});
 	}, TIMEOUT);
 
@@ -142,7 +142,7 @@ describe("Bower Installer", function() {
 			expect(err).toBeNull();
 			expectFilesToExist([
 				'test/multiMain/build/src/datejs/date.js'
-			], run);			
+			], run);
 		});
 	}, TIMEOUT);
 
@@ -153,7 +153,7 @@ describe("Bower Installer", function() {
 				'test/multiPath/build/src/buster-jquery-assertions/buster-jquery-assertions.js',
 				'test/multiPath/build/css/buster.js/buster-test.css',
 				'test/multiPath/build/src/buster.js/buster-test.js'
-			], run);			
+			], run);
 		});
 	}, TIMEOUT);
 
@@ -181,10 +181,10 @@ describe("Bower Installer", function() {
 				'test/glob/build/src/datejs/date-zh-TW.js',
 				'test/glob/build/src/datejs/date-zu-ZA.js',
 				'test/glob/build/src/datejs/date.js'
-			], run);			
+			], run);
 		});
 	}, TIMEOUT);
-	
+
 	it('Should remove bower_components directory', function(run) {
 		exec('node ../../bower-installer.js -r', {cwd: path.join(process.cwd(), 'test/basic')}, function(err, stdout, stderr) {
 			expect(err).toBeNull();
@@ -192,7 +192,7 @@ describe("Bower Installer", function() {
 				'test/basic/build/src/jquery/jquery.js',
 				'test/basic/build/src/jquery-ui/jquery-ui.js'
 			], run);
-			
+
 			expect(fs.existsSync(path.join(process.cwd(), 'bower_components'))).toBeFalsy();
 		});
 	}, TIMEOUT);
@@ -215,7 +215,7 @@ describe("Bower Installer", function() {
 				'test/keyword/build/bootstrap/3.0.3/fonts/glyphicons-halflings-regular.ttf',
 				'test/keyword/build/bootstrap/3.0.3/fonts/glyphicons-halflings-regular.woff',
 				'test/keyword/build/bootstrap/3.0.3/js/bootstrap.js'
-			], run);			
+			], run);
 		});
 	}, TIMEOUT);
 
@@ -227,7 +227,7 @@ describe("Bower Installer", function() {
 				'test/regExp/build/src/Asset/Lib/flair/Font/ubuntu-r-webfont.woff2',
 				'test/regExp/build/src/Asset/Lib/flair/Font/ubuntu-r-webfont.eot',
 				'test/regExp/build/src/Asset/Lib/flair/Font/ubuntu-r-webfont.ttf',
-				'test/regExp/build/src/Asset/Lib/flair/Font/ubuntu.font.css',
+				'test/regExp/build/src/Style/Lib/flair/ubuntu.font.scss',
 				'test/regExp/build/src/Style/Lib/flair/base.scss',
 			], run);
 		});

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -113,7 +113,7 @@ function installFile(f, pakcfg, paths, dep, silent, callback) {
         }
     }
 
-    if (!fs.lstatSync(f_name).isDirectory()) {
+    if (!fs.lstatSync(f_name).isDirectory() && f_name !== f_path) {
         utils.copyFile(f_name, f_path, function(error) {
             if (!error) {
             	if (!silent) {


### PR DESCRIPTION
if we pass the same `source` and `target` paths to `copyFile` https://github.com/blittle/bower-installer/blob/master/lib/utils.js#L94 function it will erase the file, so before calling it we have to check if `source` and `target` differs 