### PR TITLE
Allow for removal of package name from destination path

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -11,7 +11,12 @@ var basePath = process.cwd(),
     pathSep = '/',
     pathLib = path;
 
-function installFile(f, pakcfg, paths, dep, silent, callback) {
+
+var defaultInstallOptions = {
+  "includePackageNameInInstallPath": true
+};
+
+function installFile(f, pakcfg, paths, dep, silent, options, callback) {
 
     var f_s, // The path for the file to be moved
     f_name, // The full path for the file to be moved
@@ -52,22 +57,22 @@ function installFile(f, pakcfg, paths, dep, silent, callback) {
 
     } else {
         // Determine the path by regular expression...
-		path = utils.getPathByRegExp(f_name, paths)
-            // ...or by file extension.
-            || paths[utils.getExtension(f_name)]
+        path = utils.getPathByRegExp(f_name, paths)
+                // ...or by file extension.
+                || paths[utils.getExtension(f_name)]
 
         if (path && typeof path !== 'undefined') {
 
             if (!utils.hasVariableInPath(path)) {
-                path += pathSep + key + subDir; 
+                path += (options.includePackageNameInInstallPath ? pathSep + key : '') + subDir; 
             }
             else {
                 path = utils.parsePath(path, pakcfg) + subDir;
             }
 
-		}else{
-			path = '';
-		}
+        }else{
+          path = '';
+        }
     }
 
     mkdirp.sync(pathLib.normalize(basePath + pathSep + path), 0755);
@@ -136,6 +141,7 @@ exports.installDependency = function installDependency(deps, pakcfg, cfg, paths,
     var base, other;
 
     var key = pakcfg.key;
+    var options = cfg.options ? cfg.options : defaultInstallOptions
 
     // Look for an overriden source
     if (cfg.sources && cfg.sources[key]) {
@@ -143,6 +149,12 @@ exports.installDependency = function installDependency(deps, pakcfg, cfg, paths,
         deps = cfg.sources[key];
     } else {
         deps = deps.split(',');
+    }
+
+    if (deps.options) {
+      for (var p in deps.options) {
+        options[p] = deps.options[p];
+      }
     }
 
     // Check for mapping which will map old file names to new ones
@@ -163,7 +175,7 @@ exports.installDependency = function installDependency(deps, pakcfg, cfg, paths,
         // does not make sense to do a file glob, just immediately install 
         // the file
         if (_.isObject(dep)) {
-            installFile(dep, pakcfg, paths, dep, silent, callback);
+            installFile(dep, pakcfg, paths, dep, silent, options, callback);
         } else {
             glob(dep, function(err, files) {
                 if (err) {
@@ -173,7 +185,7 @@ exports.installDependency = function installDependency(deps, pakcfg, cfg, paths,
                     }
                 } else {
                     async.each(files, function(f, callback) {
-                        installFile(f, pakcfg, paths, dep, silent, callback);
+                        installFile(f, pakcfg, paths, dep, silent, options, callback);
                     }, callback);
                 }
             });

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -141,7 +141,14 @@ exports.installDependency = function installDependency(deps, pakcfg, cfg, paths,
     var base, other;
 
     var key = pakcfg.key;
-    var options = cfg.options ? cfg.options : defaultInstallOptions
+    var options = {};
+    if (cfg.options) {
+      options = cfg.options;
+    } else {
+      Object.keys(defaultInstallOptions).forEach(function(key) {
+        options[key] = defaultInstallOptions[key];
+      });
+    }
 
     // Look for an overriden source
     if (cfg.sources && cfg.sources[key]) {
@@ -151,10 +158,14 @@ exports.installDependency = function installDependency(deps, pakcfg, cfg, paths,
         deps = deps.split(',');
     }
 
-    if (deps.options) {
-      for (var p in deps.options) {
-        options[p] = deps.options[p];
-      }
+    if (deps.options && typeof deps.options === 'object') {
+      Object.keys(deps.options).forEach(function(key) {
+        if (typeof defaultInstallOptions[key] === 'undefined') {
+          console.warn("option " + key + " is not a valid install option");
+        } else {
+          options[key] = deps.options[key];
+        }
+      });
     }
 
     // Check for mapping which will map old file names to new ones


### PR DESCRIPTION
if you configure `bower_compontens/x/js/y.js` to be mapped to 'x.js' and set `options.includePackageNameInInstallPath=false`, x.js will be placed in `<DST>/x.js` instead of `<DST>/y/x.js`

The default setting for `includePackageNameInInstallPath` is `true` to not modify expected behavior.

This option can be set globally as a child of `install.options` or per package as `<PACKAGE>.options.includePackageNameInInstallPath`

Refs blittle/bower-installer#110, blittle/bower-installer#114